### PR TITLE
[ Change version ] 0.2.0 / VkHelpers::color_auto_modifi() の処理不具合修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 composer require vektor-inc/vk-helpers
 ```
 
+PHPUnit test
+```
+npm install
+npm run phpunit
+```
+
+
 == Changelog ==
+
+* 0.2.0
+  [ Bug fix ] Fix color modifi
 
 * 0.1.0
   [ Other ] Add VK_Helpers alias

--- a/src/VkHelpers.php
+++ b/src/VkHelpers.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-helpers
  * @license GPL-2.0+
  *
- * @version 0.1.0
+ * @version 0.2.0
  */
 
 namespace VektorInc\VK_Helpers;
@@ -277,7 +277,8 @@ class VkHelpers {
 	}
 
 	/**
-	 * 色を比率で明るくしたり暗くする
+	 * [ 非推奨 ] 色を比率で明るくしたり暗くする
+	 * 既にCSSのfilterなどでなどで同じような事ができるため非推奨
 	 *
 	 * @param  string  $color       #あり16進数.
 	 * @param  integer $change_rate 1 が 100%.
@@ -294,40 +295,45 @@ class VkHelpers {
 		$g = hexdec( substr( $color, 2, 2 ) );
 		$b = hexdec( substr( $color, 4, 2 ) );
 
-		// 10進数の状態で変更レートを掛けて dechex で 16進数に戻す.
-		$color_array      = array();
-		$color_array['r'] = dechex( round( self::color_adjust_under_ff( $r * $change_rate ) ) );
-		$color_array['g'] = dechex( round( self::color_adjust_under_ff( $g * $change_rate ) ) );
-		$color_array['b'] = dechex( round( self::color_adjust_under_ff( $b * $change_rate ) ) );
+		$color_array = array();
+		// 10進数の状態で変更レートを掛けて16進数で受け取る.
+		$color_array['r'] = self::color_auto_modifi_single( $r, $change_rate );
+		$color_array['g'] = self::color_auto_modifi_single( $g, $change_rate );
+		$color_array['b'] = self::color_auto_modifi_single( $b, $change_rate );
 
 		$new_color = '#';
 
 		foreach ( $color_array as $key => $value ) {
-			/*
-			桁数が１桁の場合2桁にする（ 16進数を sprintf( "%02x",$value ） しても 00 にされるため文字数が1文字のものに対して0を追加している
-			 */
-			if ( mb_strlen( $value ) < 2 ) {
-				$color_array[ $key ] = '0' . $value;
-			}
 			$new_color .= $color_array[ $key ];
 		}
 		return $new_color;
 	}
 
 	/**
-	 * 色の自動変更で255を越えてしまった時に255に強制的に抑える
-	 * ついでに小数点を四捨五入
+	 * [ 非推奨 ] RGBの個別の色をレートで変換して16進数で返す
+	 * color_auto_modifi でのみ使用されている
 	 *
-	 * @param  [type] $num RGBの10進数の数値.
+	 * @param  string  $color_num : RGBの単色の10進数の数値.
+	 * @param  integer $change_rate : 1 が 100%.
+	 * @return string $color : RGBの単色の16進数の数値.
 	 */
-	public static function color_adjust_under_ff( $num ) {
-		// $num が整数でない場合 PHP8.1 でエラーになるので四捨五入.
-		// If $num is not an integer, an error will occur in PHP8.1, so it is rounded.
-		$num = round( $num );
-		if ( $num > 256 ) {
-			$num = 255;
+	public static function color_auto_modifi_single( $color_num, $change_rate = 1 ) {
+
+		$color_num = $color_num * $change_rate;
+		if ( $color_num >= 255 ) {
+			$color_num = 255;
 		}
-		return $num;
+
+		// レートをかけて四捨五入.
+		$rounded = round( $color_num );
+
+		// 結果を16進数に変換.
+		$hex = dechex( $rounded );
+
+		// 結果がもし1桁なら2桁になるように0で埋める.
+		$color = str_pad( $hex, 2, '0', STR_PAD_LEFT );
+
+		return $color;
 	}
 
 	/**

--- a/tests/test-vk-helpers.php
+++ b/tests/test-vk-helpers.php
@@ -18,7 +18,7 @@ class VkHelpersTest extends WP_UnitTestCase {
 
 		print PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
-		print 'vk_helpers' . PHP_EOL;
+		print 'VkHelpers::get_post_type_info()' . PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
 		print PHP_EOL;
 
@@ -221,6 +221,48 @@ class VkHelpersTest extends WP_UnitTestCase {
 			// print 'expected------------------------------------' . PHP_EOL;
 			// var_dump( $value['expected'] ) . PHP_EOL;
 			// print '------------------------------------' . PHP_EOL;
+
+			$this->assertSame( $value['expected'], $actual );
+
+		}
+	}
+
+	/**
+	 * Test color_auto_modifi_single
+	 *
+	 * @return void
+	 */
+	public function test_color_auto_modifi_single() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'VkHelpers::color_auto_modifi_single()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print PHP_EOL;
+
+		$test_array = array(
+			'00'  => array(
+				'change_rate' => '1.1',
+				'color_num'   => '00',
+				'expected'    => '00',
+			),
+			'100' => array(
+				'change_rate' => '1.1',
+				'color_num'   => '100',
+				'expected'    => '6e',
+			),
+			'250' => array(
+				'change_rate' => '1.1',
+				'color_num'   => '250',
+				'expected'    => 'ff',
+			),
+		);
+		foreach ( $test_array as $key => $value ) {
+
+			// Move to test page.
+			$this->go_to( $value['target_url'] );
+
+			$actual = VkHelpers::color_auto_modifi_single( $value['color_num'], $value['change_rate'] );
 
 			$this->assertSame( $value['expected'], $actual );
 

--- a/tests/test-vk-helpers.php
+++ b/tests/test-vk-helpers.php
@@ -228,6 +228,38 @@ class VkHelpersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test color_auto_modifi
+	 *
+	 * @return void
+	 */
+	public function test_color_auto_modifi() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'VkHelpers::color_auto_modifi()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print PHP_EOL;
+
+		$test_array = array(
+			'#00a0e9'  => array(
+				'change_rate' => '1.1',
+				'color_hex'   => '#00a0e9',
+				'expected'    => '#00b0ff',
+			),
+		);
+		foreach ( $test_array as $key => $value ) {
+
+			// Move to test page.
+			$this->go_to( $value['target_url'] );
+
+			$actual = VkHelpers::color_auto_modifi( $value['color_hex'], $value['change_rate'] );
+
+			$this->assertSame( $value['expected'], $actual );
+
+		}
+	}
+
+	/**
 	 * Test color_auto_modifi_single
 	 *
 	 * @return void


### PR DESCRIPTION
色が 00a0e9 の場合、レート1.1にすると返り値が 7桁になってしまう不具合を修正