### PR TITLE
編集画面で投稿タイプを正しく取得できない不具合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ npm run phpunit
 
 == Changelog ==
 
-[ Bug fix ] Fix Unit Test
+ [ Bug fix ] Fix an issue where the correct post type was not retrieved on the post edit screen.
+ [ Bug fix ] Fix Unit Test
 
 * 0.2.0
   [ Bug fix ] Fix color modifi

--- a/src/VkHelpers.php
+++ b/src/VkHelpers.php
@@ -106,7 +106,8 @@ class VkHelpers {
 		global $pagenow;
 
 		// 管理画面で記事編集画面（wp-admin/post.php）の場合
-		if ( is_admin() && 'post.php' === $pagenow )  {
+		// ブロックエディタでは is_admin() が false になるので $GLOBALS から取得
+		if ( ( is_admin() && 'post.php' === $pagenow ) || ( ! is_admin() && isset($GLOBALS['post']) && isset($GLOBALS['post']->post_type) ) ) {
 			global $post;
 			if ( isset($post->post_type) ){
 				$post_type_info['slug'] = $post->post_type;

--- a/src/VkHelpers.php
+++ b/src/VkHelpers.php
@@ -107,7 +107,7 @@ class VkHelpers {
 
 		// 管理画面で記事編集画面（wp-admin/post.php）の場合
 		// ブロックエディタでは is_admin() が false になるので $GLOBALS から取得
-		if ( ( is_admin() && 'post.php' === $pagenow ) || ( ! is_admin() && isset($GLOBALS['post']) && isset($GLOBALS['post']->post_type) ) ) {
+		if ( ( ! is_admin() && isset($GLOBALS['post']) && isset($GLOBALS['post']->post_type) ) ) {
 			global $post;
 			if ( isset($post->post_type) ){
 				$post_type_info['slug'] = $post->post_type;

--- a/src/VkHelpers.php
+++ b/src/VkHelpers.php
@@ -103,9 +103,19 @@ class VkHelpers {
 		// When WooCommerce taxonomy archive page , get_post_type() is does not work properly.
 
 		global $wp_query;
+		global $pagenow;
+
+		// 管理画面で記事編集画面（wp-admin/post.php）の場合
+		if ( is_admin() && 'post.php' === $pagenow )  {
+			global $post;
+			if ( isset($post->post_type) ){
+				$post_type_info['slug'] = $post->post_type;
+			} else {
+				$post_type_info['slug'] = 'post';
+			}
 		// is_page() は編集画面で正しく動作しない（まぁ正しく動作しなくてもいいんですけど...）のと、
 		// 固定ページはタクソノミーアーカイブなども基本存在しないので get_post_type() を使用する.
-		if ( 'page' === get_post_type() ) {
+		} else if ( 'page' === get_post_type() ) {
 			$post_type_info['slug'] = 'page';
 		} elseif ( ! empty( $wp_query->query_vars['post_type'] ) ) {
 

--- a/src/VkHelpers.php
+++ b/src/VkHelpers.php
@@ -103,17 +103,12 @@ class VkHelpers {
 		// When WooCommerce taxonomy archive page , get_post_type() is does not work properly.
 
 		global $wp_query;
-		global $pagenow;
+		global $post;
 
-		// 管理画面で記事編集画面（wp-admin/post.php）の場合
-		// ブロックエディタでは is_admin() が false になるので $GLOBALS から取得
-		if ( ( ! is_admin() && isset($GLOBALS['post']) && isset($GLOBALS['post']->post_type) ) ) {
-			global $post;
-			if ( isset($post->post_type) ){
-				$post_type_info['slug'] = $post->post_type;
-			} else {
-				$post_type_info['slug'] = 'post';
-			}
+		// ブロックエディタで投稿タイプを取得するために最初に global $post->post_type から取得
+		// これによりループ内でも該当の投稿の投稿タイプを取得するようになった
+		if ( ! empty( $post->post_type ) ) {
+			$post_type_info['slug'] = $post->post_type;
 		// is_page() は編集画面で正しく動作しない（まぁ正しく動作しなくてもいいんですけど...）のと、
 		// 固定ページはタクソノミーアーカイブなども基本存在しないので get_post_type() を使用する.
 		} else if ( 'page' === get_post_type() ) {


### PR DESCRIPTION
https://github.com/vektor-inc/vk-blocks-pro/issues/2549

## 変更の理由

カスタム投稿タイプの編集画面で該当のカスタム投稿タイプが正しく取得できない

## 確認方法

1. vk-blocks-pro/vendor/vektor-inc/vk-helpers の中身をこれに変更するなど
2. カスタム投稿タイプの編集画面に ダイナミックテキストブロックを配置
3. 表示中のページの投稿タイプ名 に指定
4. 正しくカスタム投稿タイプ名が表示される事を確認