### PR TITLE
[ 機能追加 ] VK_Custom_Html_Control と VK_Custom_Text_Control を追加（input_type / input_attrs / label_tag フル機能）

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,85 @@ npm install
 npm run phpunit
 ```
 
+## Customizer Controls
+
+This package ships two global classes for the WordPress Customizer:
+
+- `VK_Custom_Html_Control` — outputs a heading, sub-heading and arbitrary HTML inside a Customizer section.
+- `VK_Custom_Text_Control` — text input with optional `input_before` / `input_after` strings and configurable `input_type` / `input_attrs`.
+
+Both classes are declared inside the `customize_register` action with a `class_exists` guard, so they coexist safely with themes / plugins that ship the same class name (Lightning, Katawara, etc.).
+
+### Example
+
+```php
+add_action(
+	'customize_register',
+	function ( $wp_customize ) {
+		// HTML control (heading + description).
+		$wp_customize->add_setting( 'vk_demo_html', array( 'default' => '' ) );
+		$wp_customize->add_control(
+			new VK_Custom_Html_Control(
+				$wp_customize,
+				'vk_demo_html',
+				array(
+					'label'            => __( 'Demo Section', 'your-textdomain' ),
+					'label_tag'        => 'h3',
+					'custom_title_sub' => __( 'Sub heading', 'your-textdomain' ),
+					'custom_html'      => '<p>Optional explanation HTML.</p>',
+					'section'          => 'title_tagline',
+				)
+			)
+		);
+
+		// Text control with number input and "px" suffix.
+		$wp_customize->add_setting( 'vk_demo_width', array( 'default' => 100 ) );
+		$wp_customize->add_control(
+			new VK_Custom_Text_Control(
+				$wp_customize,
+				'vk_demo_width',
+				array(
+					'label'        => __( 'Width', 'your-textdomain' ),
+					'section'      => 'title_tagline',
+					'input_type'   => 'number',
+					'input_after'  => 'px',
+					'input_attrs'  => array(
+						'min'  => 0,
+						'max'  => 1000,
+						'step' => 1,
+					),
+				)
+			)
+		);
+	},
+	20
+);
+```
+
+### Available properties
+
+`VK_Custom_Html_Control`:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `label_tag` | string | `h2` | Heading tag used to render `label`. Allowed: `h2` / `h3` / `h4` / `h5` / `h6`. |
+| `custom_title_sub` | string | `''` | Sub-heading rendered as `h3.admin-custom-h3`. |
+| `custom_html` | string | `''` | Arbitrary HTML body. Filtered through `wp_kses_post`. |
+
+`VK_Custom_Text_Control`:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `input_before` | string | `''` | HTML rendered before the input. |
+| `input_after` | string | `''` | HTML rendered after the input. |
+| `input_type` | string | `text` | HTML5 input type. Allowed: `text` / `number` / `email` / `url` / `tel` / `password` / `search`. Disallowed values fall back to `text`. |
+| `input_attrs` | array | `array()` | Extra attributes on the `input`. `type`, `value`, `style` and any `on*` event handlers are blocked. Boolean values become HTML5 boolean attributes (e.g. `'required' => true`). |
+
 
 == Changelog ==
+
+* 0.3.0
+  [ Feature ] Add VK_Custom_Html_Control and VK_Custom_Text_Control for the Customizer (with `input_type`, `input_attrs` and `label_tag` support). Previously shipped in `vk-admin` 0.6.0 / 0.6.1 / 0.7.0; consolidated here.
 
 * 0.2.1
   [ Bug fix ] Fix an issue where the correct post type was not retrieved on the post edit screen.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ add_action(
 | `input_before` | string | `''` | HTML rendered before the input. |
 | `input_after` | string | `''` | HTML rendered after the input. |
 | `input_type` | string | `text` | HTML5 input type. Allowed: `text` / `number` / `email` / `url` / `tel` / `password` / `search`. Disallowed values fall back to `text`. |
-| `input_attrs` | array | `array()` | Extra attributes on the `input`. `type`, `value`, `style` and any `on*` event handlers are blocked. Boolean values become HTML5 boolean attributes (e.g. `'required' => true`). |
+| `input_attrs` | array | `array()` | Extra attributes on the `input`. Attribute names must match the HTML attribute-name token pattern (`/^[a-zA-Z_:][a-zA-Z0-9:._-]*$/`); names containing whitespace or other invalid characters are dropped. `type`, `value`, `style` and any `on*` event handlers are blocked. Boolean values become HTML5 boolean attributes (e.g. `'required' => true`). |
 
 
 == Changelog ==

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
 	"autoload": {
 		"psr-4": {
 			"VektorInc\\VK_Helpers\\": "src/"
-		}
+		},
+		"files": [
+			"src/VK_Custom_Html_Control.php",
+			"src/VK_Custom_Text_Control.php"
+		]
 	},
 	"authors": [
 		{

--- a/src/VK_Custom_Html_Control.php
+++ b/src/VK_Custom_Html_Control.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * VK Custom Html Control loader.
+ *
+ * カスタマイザー用のカスタム HTML コントロールを提供する。
+ * WP_Customize_Control が未読込のタイミングで autoload されることを考慮し、
+ * customize_register アクション内で遅延宣言する。
+ *
+ * グローバル名前空間に置くため、composer.json の autoload.files で読み込む。
+ *
+ * @package VektorInc\VK_Helpers
+ */
+
+// WordPress 環境（add_action がある）でのみフックを登録する。
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'customize_register', 'vk_helpers_register_custom_html_control', 0 );
+}
+
+if ( ! function_exists( 'vk_helpers_register_custom_html_control' ) ) {
+	/**
+	 * VK_Custom_Html_Control クラスを customize_register のタイミングで宣言する。
+	 *
+	 * WP_Customize_Control はカスタマイザー画面でのみ読み込まれるため、
+	 * autoload 時点では存在しない可能性がある。そのため customize_register
+	 * フック内で class_exists ガード付きで宣言する。
+	 *
+	 * @return void
+	 */
+	function vk_helpers_register_custom_html_control() {
+		// WP_Customize_Control が未読込、または既に同名クラスが定義済みなら何もしない。
+		if ( ! class_exists( 'WP_Customize_Control', false ) || class_exists( 'VK_Custom_Html_Control', false ) ) {
+			return;
+		}
+
+		/**
+		 * VK_Custom_Html_Control
+		 *
+		 * カスタマイザーセクション内に任意の見出し・サブ見出し・HTML を出力する
+		 * 設定なしのコントロール。設定セクションの説明用に使うことを想定。
+		 */
+		class VK_Custom_Html_Control extends WP_Customize_Control {
+
+			/**
+			 * Control type.
+			 *
+			 * @var string
+			 */
+			public $type = 'customtext';
+
+			/**
+			 * サブタイトル（h3 で出力される追加見出し）。
+			 *
+			 * @var string
+			 */
+			public $custom_title_sub = '';
+
+			/**
+			 * 任意の HTML 本文。wp_kses_post でサニタイズされる。
+			 *
+			 * @var string
+			 */
+			public $custom_html = '';
+
+			/**
+			 * label の出力に使う見出しタグ。許可: h2/h3/h4/h5/h6。
+			 *
+			 * @var string
+			 */
+			public $label_tag = 'h2';
+
+			/**
+			 * コントロールの中身を出力する。
+			 *
+			 * label / custom_title_sub / custom_html をそれぞれ条件付きで出力する。
+			 *
+			 * @return void
+			 */
+			public function render_content() {
+				// label が指定されていれば、label_tag で指定された見出しタグで出力する。
+				if ( $this->label ) {
+					// 許可する見出しタグの一覧。許可外が来た場合は h2 にフォールバックする。
+					$allowed_tags = array( 'h2', 'h3', 'h4', 'h5', 'h6' );
+					$label_tag    = in_array( strtolower( (string) $this->label_tag ), $allowed_tags, true ) ? strtolower( (string) $this->label_tag ) : 'h2';
+					// クラス名は admin-custom-{tag} の規則で生成する（既存テーマの CSS と互換）。
+					$label_class  = 'admin-custom-' . $label_tag;
+					printf(
+						'<%1$s class="%2$s">%3$s</%1$s>',
+						esc_attr( $label_tag ),
+						esc_attr( $label_class ),
+						wp_kses_post( $this->label )
+					);
+				}
+				// サブタイトルがあれば h3 で出力する。
+				if ( $this->custom_title_sub ) {
+					echo '<h3 class="admin-custom-h3">' . wp_kses_post( $this->custom_title_sub ) . '</h3>';
+				}
+				// 任意 HTML があれば div でラップして出力する。
+				if ( $this->custom_html ) {
+					echo '<div>' . wp_kses_post( $this->custom_html ) . '</div>';
+				}
+			}
+		}
+	}
+}

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -109,8 +109,14 @@ if ( ! function_exists( 'vk_helpers_register_custom_text_control' ) ) {
 							<?php
 							// input_attrs を 1 つずつ吐き出す。
 							foreach ( $input_attrs as $attr_name => $attr_value ) :
-								// キーが文字列でない or 空文字なら無視。
-								if ( ! is_string( $attr_name ) || '' === $attr_name ) {
+								// キーが文字列でない場合は無視。
+								if ( ! is_string( $attr_name ) ) {
+									continue;
+								}
+								$attr_name = trim( $attr_name );
+								// HTML 属性名トークンのみ許可（空白・記号混入を拒否）。
+								// 「foo onfocus」のようなキーで on* チェックを迂回されるのを防ぐ。
+								if ( '' === $attr_name || ! preg_match( '/^[a-zA-Z_:][a-zA-Z0-9:._-]*$/', $attr_name ) ) {
 									continue;
 								}
 								$attr_name_lc = strtolower( $attr_name );

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * VK Custom Text Control loader.
+ *
+ * カスタマイザー用のカスタムテキスト入力コントロールを提供する。
+ * input_before / input_after で入力欄の前後に文字列を付けたり、
+ * input_type で text 以外（number, email, url など）を指定できる。
+ *
+ * WP_Customize_Control が未読込のタイミングで autoload されることを考慮し、
+ * customize_register アクション内で遅延宣言する。
+ *
+ * グローバル名前空間に置くため、composer.json の autoload.files で読み込む。
+ *
+ * @package VektorInc\VK_Helpers
+ */
+
+// WordPress 環境（add_action がある）でのみフックを登録する。
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'customize_register', 'vk_helpers_register_custom_text_control', 0 );
+}
+
+if ( ! function_exists( 'vk_helpers_register_custom_text_control' ) ) {
+	/**
+	 * VK_Custom_Text_Control クラスを customize_register のタイミングで宣言する。
+	 *
+	 * WP_Customize_Control はカスタマイザー画面でのみ読み込まれるため、
+	 * autoload 時点では存在しない可能性がある。そのため customize_register
+	 * フック内で class_exists ガード付きで宣言する。
+	 *
+	 * @return void
+	 */
+	function vk_helpers_register_custom_text_control() {
+		// WP_Customize_Control が未読込、または既に同名クラスが定義済みなら何もしない。
+		if ( ! class_exists( 'WP_Customize_Control', false ) || class_exists( 'VK_Custom_Text_Control', false ) ) {
+			return;
+		}
+
+		/**
+		 * VK_Custom_Text_Control
+		 *
+		 * 入力欄の前後に文字列を付与できる拡張テキストコントロール。
+		 * input_type で number/email/url 等の HTML5 入力タイプを切り替えられる。
+		 */
+		class VK_Custom_Text_Control extends WP_Customize_Control {
+
+			/**
+			 * Control type.
+			 *
+			 * @var string
+			 */
+			public $type = 'customtext';
+
+			/**
+			 * input 要素の前に出力する HTML。例: 単位ラベル等。
+			 *
+			 * @var string
+			 */
+			public $input_before = '';
+
+			/**
+			 * input 要素の後ろに出力する HTML。例: "px" "%" 等の単位。
+			 *
+			 * @var string
+			 */
+			public $input_after = '';
+
+			/**
+			 * input 要素の type 属性。許可: text/number/email/url/tel/password/search。
+			 *
+			 * @var string
+			 */
+			public $input_type = 'text';
+
+			/**
+			 * input 要素に追加する属性の連想配列。
+			 *
+			 * 例: array( 'min' => 0, 'max' => 100, 'step' => 1 )
+			 * type/value/style/on* 属性は予約済みのため指定不可。
+			 *
+			 * @var array
+			 */
+			public $input_attrs = array();
+
+			/**
+			 * コントロールの中身を出力する。
+			 *
+			 * @return void
+			 */
+			public function render_content() {
+				// 許可する input type の一覧。許可外が来た場合は text にフォールバックする。
+				$allowed_input_types = array( 'text', 'number', 'email', 'url', 'tel', 'password', 'search' );
+				$input_type = ( is_string( $this->input_type ) && '' !== $this->input_type && in_array( strtolower( $this->input_type ), $allowed_input_types, true ) ) ? strtolower( $this->input_type ) : 'text';
+
+				// input_attrs は配列であることを保証する。
+				$input_attrs = is_array( $this->input_attrs ) ? $this->input_attrs : array();
+
+				// 予約属性。これらは input_attrs で上書きさせない。
+				$reserved_attrs = array( 'type', 'value', 'style' );
+				?>
+				<label>
+					<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+					<?php
+					// 前後にテキストがある場合は input の幅を 50% に縮めて見た目を整える。
+					$style = ( $this->input_before || $this->input_after ) ? ' style="width:50%"' : '';
+					?>
+					<div>
+						<?php echo wp_kses_post( $this->input_before ); ?>
+						<input type="<?php echo esc_attr( $input_type ); ?>" value="<?php echo esc_attr( $this->value() ); ?>"<?php echo $style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で定義した固定文字列のみ。 ?>
+							<?php
+							// input_attrs を 1 つずつ吐き出す。
+							foreach ( $input_attrs as $attr_name => $attr_value ) :
+								// キーが文字列でない or 空文字なら無視。
+								if ( ! is_string( $attr_name ) || '' === $attr_name ) {
+									continue;
+								}
+								$attr_name_lc = strtolower( $attr_name );
+								// on* イベントハンドラと予約属性はスキップ（XSS / 衝突回避）。
+								if ( 0 === strpos( $attr_name_lc, 'on' ) || in_array( $attr_name_lc, $reserved_attrs, true ) ) {
+									continue;
+								}
+								// 真偽値は「属性名だけ出力 or 出力しない」の動作にする（HTML5 boolean attribute）。
+								if ( is_bool( $attr_value ) ) {
+									if ( $attr_value ) {
+										echo ' ' . esc_attr( $attr_name );
+									}
+									continue;
+								}
+								// null や非スカラー（配列・オブジェクト）はスキップする。
+								if ( null === $attr_value || ! is_scalar( $attr_value ) ) {
+									continue;
+								}
+								?>
+								<?php echo esc_attr( $attr_name ); ?>="<?php echo esc_attr( (string) $attr_value ); ?>"
+							<?php endforeach; ?>
+							<?php $this->link(); ?> />
+						<?php echo wp_kses_post( $this->input_after ); ?>
+					</div>
+					<?php if ( $this->description ) : ?>
+						<div><?php echo wp_kses_post( $this->description ); ?></div>
+					<?php endif; ?>
+				</label>
+				<?php
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 概要

カスタマイザー用の汎用 control クラス `VK_Custom_Html_Control` / `VK_Custom_Text_Control` を vk-helpers に追加します。

これまで vk-admin 側に追加していた同等クラスを vk-helpers に集約する方針変更（「vk-admin はベクター固有の設定画面用、汎用カスタマイザー control は vk-helpers に一本化」）に基づくものです。

### 経緯

vk-admin 側で段階的に整備していた同等クラスを、設計的に「汎用ヘルパー側に置くべき」とユーザー判断で方針変更。今回の vk-helpers への追加で、vk-admin の以下の改修分を **一発で集約** します。

- vk-admin 0.6.0: `VK_Custom_Html_Control` / `VK_Custom_Text_Control` の追加（基本機能）
- vk-admin 0.6.1: autoload 遅延宣言の修正（`customize_register` 内で `class_exists` ガード付き宣言）
- vk-admin 0.7.0: `VK_Custom_Text_Control` に `input_type` / `input_attrs` を追加
- vk-admin 側 PR #15 で検討していた `label_tag`（h2/h3/h4/h5/h6 切替）も同梱

## 追加機能まとめ

### VK_Custom_Html_Control

| プロパティ | 型 | 既定値 | 説明 |
|---|---|---|---|
| `label_tag` | string | `h2` | label を出力する見出しタグ（h2/h3/h4/h5/h6） |
| `custom_title_sub` | string | `''` | サブ見出し（h3 で出力） |
| `custom_html` | string | `''` | 任意の HTML 本文（`wp_kses_post` で消毒） |

### VK_Custom_Text_Control

| プロパティ | 型 | 既定値 | 説明 |
|---|---|---|---|
| `input_before` | string | `''` | input 要素の前に出力する HTML |
| `input_after` | string | `''` | input 要素の後ろに出力する HTML（"px" 等の単位） |
| `input_type` | string | `text` | text/number/email/url/tel/password/search（許可外は text にフォールバック） |
| `input_attrs` | array | `array()` | input 要素の追加属性。`type`/`value`/`style` および `on*` イベント属性はブロック。bool 値は HTML5 boolean attribute として扱う |

## 実装上のポイント

### 名前空間と autoload

vk-admin 側のクラスがグローバル名前空間 `VK_Custom_Html_Control` / `VK_Custom_Text_Control` で、既存利用者（Lightning g2/g3, Lightning Pro, katawara 等）が直書きで同名 class を持つため、互換維持のためグローバル名前空間に置きました。

- PSR-4 と衝突しないよう、composer.json の `autoload.files` で読み込み
- ファイル本体は `src/VK_Custom_*_Control.php`（PSR-4 の `src/` に同居するが、autoload.files で個別ロードするため衝突なし）

### 遅延宣言と class_exists ガード

`WP_Customize_Control` はカスタマイザー画面でのみ読まれるため、autoload 時に extends すると fatal の恐れがあります。そのため:

1. `autoload.files` でロードされるのは「`add_action` を仕掛ける関数定義」だけ
2. `customize_register` フック内（優先度 0）でクラス本体を宣言
3. `class_exists( ..., false )` ガードで、既存テーマ・プラグインが先に同名クラスを宣言済みでも fatal にならない

これにより、Lightning g3 や katawara のようにテーマ側で同じクラスを直書きしているプロジェクトでも、vk-helpers 側が黙って降りる形で共存できます。

## 確認手順

### 前提条件

- 任意の WordPress 環境（5.x 以降）でテーマ or プラグインから `composer require vektor-inc/vk-helpers:dev-feature/add-customize-controls` で本ブランチを読み込む
- もしくは本リポジトリを `wp-content/plugins/vk-helpers/` に配置

### 手順

#### 1. クラスが存在しないこと（autoload 時点）

1. WordPress を起動し、フロント側を表示する
2. `class_exists( 'VK_Custom_Html_Control', false )` を確認
   → ✓ `false`（autoload 時点では宣言されていない）

#### 2. customize_register でクラスが宣言される

1. WordPress 管理画面の「外観 > カスタマイズ」を開く
2. `class_exists( 'VK_Custom_Html_Control', false )` / `class_exists( 'VK_Custom_Text_Control', false )` を確認
   → ✓ どちらも `true`

#### 3. VK_Custom_Html_Control の動作確認

以下のコードを `functions.php` 等に追加:

```php
add_action(
	'customize_register',
	function ( $wp_customize ) {
		$wp_customize->add_setting( 'vk_demo_html', array( 'default' => '' ) );
		$wp_customize->add_control(
			new VK_Custom_Html_Control(
				$wp_customize,
				'vk_demo_html',
				array(
					'label'            => 'Demo Section',
					'label_tag'        => 'h3',
					'custom_title_sub' => 'Sub heading',
					'custom_html'      => '<p>Explanation HTML.</p>',
					'section'          => 'title_tagline',
				)
			)
		);
	},
	20
);
```

1. カスタマイザーの「サイト基本情報」セクションを開く
2. `<h3 class="admin-custom-h3">Demo Section</h3>` が表示されることを確認
   → ✓ label_tag が反映され h3 で出力される
3. その下に `<h3 class="admin-custom-h3">Sub heading</h3>` と `<div><p>Explanation HTML.</p></div>` が表示される
   → ✓ custom_title_sub / custom_html が出力される
4. `label_tag` を未指定にして再表示
   → ✓ h2 で出力される（既定値）
5. `label_tag` に `script` 等の不正値を入れて再表示
   → ✓ h2 にフォールバック（不正値は使われない）

#### 4. VK_Custom_Text_Control の動作確認

```php
add_action(
	'customize_register',
	function ( $wp_customize ) {
		$wp_customize->add_setting( 'vk_demo_width', array( 'default' => 100 ) );
		$wp_customize->add_control(
			new VK_Custom_Text_Control(
				$wp_customize,
				'vk_demo_width',
				array(
					'label'       => 'Width',
					'section'     => 'title_tagline',
					'input_type'  => 'number',
					'input_after' => 'px',
					'input_attrs' => array(
						'min'  => 0,
						'max'  => 1000,
						'step' => 1,
					),
				)
			)
		);
	},
	20
);
```

1. カスタマイザーの「サイト基本情報」セクションを開く
2. 数値入力欄が表示され、後ろに "px" が表示される
   → ✓ `<input type="number" min="0" max="1000" step="1">` + `px`
3. `input_type` を `email` に変えて再表示
   → ✓ `type="email"` で出力
4. `input_type` を `script` 等の不正値にする
   → ✓ `type="text"` にフォールバック
5. `input_attrs` に `onclick => 'alert(1)'` を入れる
   → ✓ `onclick` は出力されない（`on*` 属性はブロック）
6. `input_attrs` に `required => true` を入れる
   → ✓ `required` 属性（値なしの boolean attribute）として出力される

#### 5. 既存利用者との互換性

1. Lightning g3 などクラスを直書きしているテーマと併用する
2. `class_exists( 'VK_Custom_Html_Control', false )` を確認
   → ✓ 先に宣言した側が勝ち、vk-helpers 側は黙って降りる（PHP fatal なし）

## 補足

- composer.json のバージョン番号は本 PR では変更していません（タグ付けは司側で `0.3.0` を予定）
- 既存 `VkHelpers.php`（PSR-4 namespace 配下）には触っていません
- 既存テスト（`tests/test-vk-helpers.php`）の対象クラスは未変更のため、デグレなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WordPress カスタマイザ向けのカスタム HTML コントロールを追加しました
  * カスタムテキスト入力コントロールを追加しました

* **Documentation**
  * カスタマイザーコントロールの用途、利用可能なプロパティ、サンプルコードをREADMEに追加しました

* **Chores**
  * バージョン 0.3.0 のリリース情報をチェンジログに追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-helpers/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->